### PR TITLE
- fixes test failures on Windows and OS X

### DIFF
--- a/unittests/SireIO/test_amberrst.py
+++ b/unittests/SireIO/test_amberrst.py
@@ -112,7 +112,11 @@ def test_amberrst(verbose=False):
     if verbose:
         print("Writing back to a full file...")
 
-    os.system("rm test.rst test.prm7")
+    for t in ("test.rst", "test.prm7"):
+        try:
+            os.remove(t)
+        except:
+            pass
 
     if verbose:
         print("Writing...")

--- a/unittests/SireIO/test_locale.py
+++ b/unittests/SireIO/test_locale.py
@@ -12,7 +12,7 @@ import os
 
 from nose.tools import assert_equal
 
-sire_python = "%s/python" % Sire.Config.binary_directory
+sire_python = sys.executable
 
 gromacs_path = StringProperty("../io/gromacs")
 


### PR DESCRIPTION
Windows does not have the `rm` shell command, so I replaced it with `os.remove()`.
`test_locale.py` was segfaulting on OS X as it used `python` rather than `sire_python`.