### PR TITLE
Only set OPENMM_PLUGIN_DIR if it is not already set

### DIFF
--- a/unittests/OpenMM/test_kinetic_energies.py
+++ b/unittests/OpenMM/test_kinetic_energies.py
@@ -11,7 +11,10 @@ np = Sire.try_import("numpy")
 
 from nose.tools import assert_almost_equal
 plugins = os.path.join('lib','plugins')
-os.environ["OPENMM_PLUGIN_DIR"] = os.path.join(Sire.Base.getInstallDir(),plugins)
+try:
+    os.environ["OPENMM_PLUGIN_DIR"]
+except KeyError:
+    os.environ["OPENMM_PLUGIN_DIR"] = os.path.join(Sire.Base.getInstallDir(),plugins)
 
 
 (mols, space) = Amber().readCrdTop("../io/ethane.crd", "../io/ethane.top")

--- a/unittests/OpenMM/test_setup_openmmd.py
+++ b/unittests/OpenMM/test_setup_openmmd.py
@@ -11,7 +11,10 @@ import numpy as np
 
 from nose.tools import assert_almost_equal
 plugins = os.path.join('lib','plugins')
-os.environ["OPENMM_PLUGIN_DIR"] = os.path.join(Sire.Base.getInstallDir(),plugins)
+try:
+    os.environ["OPENMM_PLUGIN_DIR"]
+except KeyError:
+    os.environ["OPENMM_PLUGIN_DIR"] = os.path.join(Sire.Base.getInstallDir(),plugins)
 
 
 (mols, space) = Amber().readCrdTop("../io/ala.crd", "../io/ala.top")


### PR DESCRIPTION
The user may have already set `OPENMM_PLUGIN_DIR` to point to a custom location, so the test script should only set it to the default location if it is not already set.