### PR TITLE
Fix infinite loop and nose zipfile import issue in test_locale.py

### DIFF
--- a/unittests/SireIO/test_locale.py
+++ b/unittests/SireIO/test_locale.py
@@ -10,9 +10,10 @@ import shlex
 import sys
 import os
 
-#from nose.tools import assert_equal
+from nose.tools import assert_equal
 
-sire_python = sys.executable
+sire_python = os.path.join(os.path.dirname(sys.executable), "sire_python")
+
 gromacs_path = StringProperty("../io/gromacs")
 
 def _test_broken_pdb():
@@ -42,14 +43,14 @@ def _test_broken_pdb():
 
     m2 = s[MolIdx(0)]
 
-    assert( m.nAtoms() == m2.nAtoms() )
+    assert_equal( m.nAtoms(), m2.nAtoms() )
 
     for i in range(0, m.nAtoms()):
         if verbose:
             print("%s vs %s" % (m.atoms()[i].property("coordinates"),
                                 m2.atoms()[i].property("coordinates")))
 
-        assert( m.atoms()[i].property("coordinates") == 
+        assert_equal( m.atoms()[i].property("coordinates"), 
                       m2.atoms()[i].property("coordinates") )
 
     # now try the same with PDB2
@@ -66,14 +67,14 @@ def _test_broken_pdb():
 
     m2 = s[MolIdx(0)]
 
-    assert( m.nAtoms() == m2.nAtoms() )
+    assert_equal( m.nAtoms(), m2.nAtoms() )
 
     for i in range(0, m.nAtoms()):
         if verbose:
             print("%s vs %s" % (m.atoms()[i].property("coordinates"),
                                 m2.atoms()[i].property("coordinates")))
 
-        assert( m.atoms()[i].property("coordinates") ==
+        assert_equal( m.atoms()[i].property("coordinates"),
                       m2.atoms()[i].property("coordinates") )
 
 def _test_broken_rst7():
@@ -110,7 +111,7 @@ def _test_broken_rst7():
             v1 = m1.atoms()[j].property("coordinates")
             v2 = m2.atoms()[j].property("coordinates")
 
-            assert(v1 == v2)
+            assert_equal(v1, v2)
 
     if verbose:
         print("All ok :-)")    
@@ -150,7 +151,7 @@ def _test_broken_gro():
             v1 = m1.atoms()[j].property("coordinates")
             v2 = m2.atoms()[j].property("coordinates")
 
-            assert(v1 == v2)
+            assert_equal(v1, v2)
 
     if verbose:
         print("All ok :-)")    
@@ -162,7 +163,7 @@ def _test_broken_function(verbose, function):
     if verbose:
         print(cmd)
 
-    env = dict(os.environ, LC_ALL="fr_FR")
+    env = dict(os.environ, LC_ALL="it_IT")
 
     if verbose:
         env["VERBOSE_TEST"] = "1"

--- a/unittests/SireIO/test_locale.py
+++ b/unittests/SireIO/test_locale.py
@@ -1,20 +1,19 @@
 
-#from Sire.IO import *
-#from Sire.Mol import *
-#from Sire.Base import *
+from Sire.IO import *
+from Sire.Mol import *
+from Sire.Base import *
 
-#import Sire.Config
+import Sire.Config
 
 import subprocess
 import shlex
 import sys
 import os
 
-from nose.tools import assert_equal
+#from nose.tools import assert_equal
 
 sire_python = sys.executable
-
-#gromacs_path = StringProperty("../io/gromacs")
+gromacs_path = StringProperty("../io/gromacs")
 
 def _test_broken_pdb():
     try:
@@ -43,14 +42,14 @@ def _test_broken_pdb():
 
     m2 = s[MolIdx(0)]
 
-    assert_equal( m.nAtoms(), m2.nAtoms() )
+    assert( m.nAtoms() == m2.nAtoms() )
 
     for i in range(0, m.nAtoms()):
         if verbose:
             print("%s vs %s" % (m.atoms()[i].property("coordinates"),
                                 m2.atoms()[i].property("coordinates")))
 
-        assert_equal( m.atoms()[i].property("coordinates"), 
+        assert( m.atoms()[i].property("coordinates") == 
                       m2.atoms()[i].property("coordinates") )
 
     # now try the same with PDB2
@@ -67,14 +66,14 @@ def _test_broken_pdb():
 
     m2 = s[MolIdx(0)]
 
-    assert_equal( m.nAtoms(), m2.nAtoms() )
+    assert( m.nAtoms() == m2.nAtoms() )
 
     for i in range(0, m.nAtoms()):
         if verbose:
             print("%s vs %s" % (m.atoms()[i].property("coordinates"),
                                 m2.atoms()[i].property("coordinates")))
 
-        assert_equal( m.atoms()[i].property("coordinates"),
+        assert( m.atoms()[i].property("coordinates") ==
                       m2.atoms()[i].property("coordinates") )
 
 def _test_broken_rst7():
@@ -111,7 +110,7 @@ def _test_broken_rst7():
             v1 = m1.atoms()[j].property("coordinates")
             v2 = m2.atoms()[j].property("coordinates")
 
-            assert_equal(v1, v2)
+            assert(v1 == v2)
 
     if verbose:
         print("All ok :-)")    
@@ -151,7 +150,7 @@ def _test_broken_gro():
             v1 = m1.atoms()[j].property("coordinates")
             v2 = m2.atoms()[j].property("coordinates")
 
-            assert_equal(v1, v2)
+            assert(v1 == v2)
 
     if verbose:
         print("All ok :-)")    
@@ -195,10 +194,10 @@ funcs["--test_broken_rst7"] = _test_broken_rst7
 funcs["--test_broken_gro"] = _test_broken_gro
 
 if __name__ == "__main__":
-    #if len(sys.argv) > 1:
-    #    funcs[sys.argv[1]]()
-    #else:
-    #    test_broken_pdb(True)
-    #    test_broken_rst7(True)
-    #    test_broken_gro(True)
-    print("DISABLING LOCALE TEST AS INFINITE LOOP")
+    if len(sys.argv) > 1:
+        funcs[sys.argv[1]]()
+    else:
+        test_broken_pdb(True)
+        test_broken_rst7(True)
+        test_broken_gro(True)
+    #print("DISABLING LOCALE TEST AS INFINITE LOOP")


### PR DESCRIPTION
It looks like what breaks `test_locale.py` is the fact of importing a `nose` module and the re-running itself (which is required by the need of setting a different locale). Avoiding to import `nose.tools.assert_equal` and using Python `assert` instead seems to work fine both when running the test standalone and through `nose`.