### PR TITLE
Fixes a few test failures on Windows

### DIFF
--- a/unittests/SireIO/test_analyse_freenrg.py
+++ b/unittests/SireIO/test_analyse_freenrg.py
@@ -8,7 +8,11 @@ def test_analyse_freenrg(verbose=False):
     if verbose:
         print("Analysing free energy...")
 
-    output = os.popen("%s/analyse_freenrg -i ../io/freenrgs.s3" % Sire.Config.binary_directory).readlines()
+    if os.path.exists("%s/analyse_freenrg" % Sire.Config.binary_directory):
+        output = os.popen("%s/analyse_freenrg -i ../io/freenrgs.s3" % Sire.Config.binary_directory).readlines()
+    else:
+        output = os.popen("%s/sire_python %s/scripts/analyse_freenrg.py -i ../io/freenrgs.s3"
+            % (Sire.Config.binary_directory, Sire.Config.share_directory)).readlines()
 
     if verbose:
         print("Complete!")

--- a/unittests/SireIO/test_cathepsin.py
+++ b/unittests/SireIO/test_cathepsin.py
@@ -6,6 +6,7 @@ from Sire.MM import *
 from Sire.CAS import *
 
 import glob
+import os
 
 from nose.tools import assert_equal
 
@@ -85,6 +86,10 @@ def _test_input(prm, crd, verbose=False, slow_tests=False):
     r = AmberRst7(crd)
 
     a = AmberPrm(prm)
+
+    d = os.path.dirname("test-%s" % root)
+    if (not os.path.isdir(d)):
+        os.mkdir(d)
 
     a.writeToFile("test-%s.prm" % root)
 

--- a/unittests/SireIO/test_charmmpsf.py
+++ b/unittests/SireIO/test_charmmpsf.py
@@ -28,7 +28,7 @@ def test_multi_parse(verbose=False):
 
     # Glob all of the NAMD example directories, removing the README.md file.
     dirs = glob('../io/namd/*')
-    dirs.remove('../io/namd/README.md')
+    [dirs.remove(d) for d in dirs if d.endswith('README.md')]
 
     print(dirs)
 


### PR DESCRIPTION
A few `SireIO` tests are currently failing on Windows because:
1) symlinks to Python scripts do not exist on Windows; the fix is just to run the corresponding Python script using `sire_python.exe` as the interpreter
2) an attempt is made to write to a directory which does not exist yet
3) `glob` may introduce backslashes in the path instead of slashes. As a consequence, the attempt to remove `../io/namd/README.md` fails as the file is listed as `../io/namd\\README.md` instead.